### PR TITLE
Fixed serious error in russian translation

### DIFF
--- a/app/src/main/res/values-ru/strings-ru.xml
+++ b/app/src/main/res/values-ru/strings-ru.xml
@@ -302,7 +302,7 @@
     <string name="xdrip_plus_extra_settings">Дополнительные настройки xDrip+</string>
     <string name="example_chart">Пример графика</string>
     <string name="treatments_prediction_curves">Введённые значения / Прогнозные кривые</string>
-    <string name="carbs_per_unit">Кол-во углеводов в 1 ХЕ</string>
+    <string name="carbs_per_unit">Углеводный коэффициент: сколько грамм углеводов покрывает 1 ед. инсулина</string>
     <string name="everyday">Ежедневно</string>
     <string name="insulin_sensitivity_glucose_drop_per_unit">Чувствительность к инсулину: спад глюкозы от 1 ед. инсулина</string>
     <string name="transmitter_battery">Батарея трансмиттера</string>


### PR DESCRIPTION
"Carbs Per Unit" was translated as "grams of carb in one **carbohydrate** unit (XE - хлебная единица)", not "grams of carb, covered by one **insulin** unit"